### PR TITLE
Add fallback scrape protocol to ServiceMonitor

### DIFF
--- a/charts/near-protocol/Chart.yaml
+++ b/charts/near-protocol/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: near-protocol
 description: A Helm chart for deploying NEAR Protocol nodes
-version: 1.1.6
+version: 1.1.7
 appVersion: "1.0"

--- a/charts/near-protocol/templates/service-monitor.yaml
+++ b/charts/near-protocol/templates/service-monitor.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     {{- include "near-node.labels" . | nindent 4 }}
 spec:
+  fallbackScrapeProtocol: {{ .Values.serviceMonitor.fallbackScrapeProtocol }}
   selector:
     matchLabels:
       {{- include "near-node.selectorLabels" . | nindent 6 }}

--- a/charts/near-protocol/values.yaml
+++ b/charts/near-protocol/values.yaml
@@ -77,6 +77,7 @@ serviceMonitor:
   enabled: false
   interval: 30s
   path: null
+  fallbackScrapeProtocol: PrometheusText1.0.0
 
 # Persistent volume claim configuration
 volumeClaimTemplates:


### PR DESCRIPTION
Prometheus 3.0 (released November 2024) is a lot stricter on content-type headers coming from the targets. This causes the targets deployed with this chart to be unreachable. This PR adds a fallback protocol to the ServiceMonitor to solve the issue until the upstream project updates their Prometheus client library.

https://prometheus.io/docs/prometheus/3.0/migration/#scrape-protocols